### PR TITLE
Fix > Image switch not working bug

### DIFF
--- a/assets/dropdown.css
+++ b/assets/dropdown.css
@@ -8,14 +8,13 @@ select {
 .yc-dropdown {
   box-sizing: border-box;
   cursor: pointer;
-  display: block;
+  display: inline-block;
   font-family: inherit;
   position: relative;
-  text-align: left !important;
   transition: all 0.2s ease-in-out;
   user-select: none;
   white-space: nowrap;
-  width: auto;
+  width: 100%;
 }
 
 .yc-dropdown:hover {

--- a/layouts/theme.liquid
+++ b/layouts/theme.liquid
@@ -17,9 +17,5 @@
     {{ content_for_layout }}
 
     {{ 'main.js' | asset_url | script_tag }}
-    {{ 'dropdown.min.js' | asset_url | script_tag }}
-    {%- javascript -%}
-      document.querySelectorAll('select').forEach((select) => NiceSelect.bind(select));
-    {%- endjavascript -%}
   </body>
 </html>

--- a/styles/dropdown.scss
+++ b/styles/dropdown.scss
@@ -8,14 +8,13 @@ select {
 .yc-dropdown {
   box-sizing: border-box;
   cursor: pointer;
-  display: block;
+  display: inline-block;
   font-family: inherit;
   position: relative;
-  text-align: left !important;
   transition: all 0.2s ease-in-out;
   user-select: none;
   white-space: nowrap;
-  width: auto;
+  width: 100%;
 }
 .yc-dropdown:hover {
   border-color: #dbdbdb;


### PR DESCRIPTION
The issue was caused by an external dropdown library that was causing problems with the productDetails feature. I found that this library was causing issues by listening for clicks on the page and changing the select attributes, which triggered the mutation observer of the productDetails. To fix the issue, I removed the external library and am using the default select HTML until I can work on improving the styling.
