### PR TITLE
YSHOP2-186: COD theme > Custom field issue

### DIFF
--- a/assets/express-checkout.js
+++ b/assets/express-checkout.js
@@ -26,7 +26,8 @@ async function placeOrder() {
         if (!form || !formFields) return;
 
         formFields.forEach((field) => {
-          const input = form.querySelector(`input[name="${field}"]`);
+          const fieldName = field.replace('extra_fields.', 'extra_fields[') + ']';
+          const input = form.querySelector(`input[name="${fieldName}"]`);
           const errorEl = form.querySelector(`.validation-error[data-error="${field}"]`);
 
           if (input) {

--- a/assets/express-checkout.js
+++ b/assets/express-checkout.js
@@ -26,7 +26,7 @@ async function placeOrder() {
         if (!form || !formFields) return;
 
         formFields.forEach((field) => {
-          const fieldName = field.replace('extra_fields.', 'extra_fields[') + ']';
+          const fieldName = field.indexOf('extra_fields') > -1 ? field.replace('extra_fields.', 'extra_fields[') + ']' : field;
           const input = form.querySelector(`input[name="${fieldName}"]`);
           const errorEl = form.querySelector(`.validation-error[data-error="${field}"]`);
 

--- a/snippets/express-checkout.liquid
+++ b/snippets/express-checkout.liquid
@@ -92,7 +92,11 @@
         >
         <div
           class='validation-error'
-          data-error='{{ field.name }}'
+          {% if field.custom %}
+            data-error='extra_fields.{{ field.name }}'
+          {% else %}
+            data-error='{{ field.name }}'
+          {% endif %}
         ></div>
       </div>
     {%- endfor %}

--- a/snippets/express-checkout.liquid
+++ b/snippets/express-checkout.liquid
@@ -80,7 +80,11 @@
           type='{{ field.type }}'
           class='w-full'
           id='{{ field.name }}'
-          name='{{ field.name }}'
+          {% if field.custom %}
+            name='extra_fields[{{ field.name }}]'
+          {% else %}
+            name='{{ field.name }}'
+          {% endif %}
           placeholder='{{ field.placeholder }}'
           {% if field.required %}
             required


### PR DESCRIPTION
## JIRA Ticket

[YSHOP2-186](https://youcanshop.atlassian.net/browse/YSHOP2-186)

## QA Steps

- [ ] `pnpm i`
- [ ] `pnpm dev`
- [ ] Make sure you have custom fields in your checkout
- [ ] Go to product page and attempt to purchase the product
- [ ] Keep form fields empty and press the buy button
- [ ] The form should show all the fields in red + their error messages
- [ ] We should not get any flash message with `add event listener` error

## Note

Leave empty when you have nothing to say


[YSHOP2-186]: https://youcanshop.atlassian.net/browse/YSHOP2-186?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ