### PR TITLE
YSHOP2-316: Products List > Wrong position of the banner when set in the bottom

### DIFF
--- a/snippets/product-preview.liquid
+++ b/snippets/product-preview.liquid
@@ -5,15 +5,6 @@
   href='{{ item.url }}'
   class='product-block'
 >
-
-  {% if block_settings.tag_text %}
-    <div
-      class="tag {{ block_settings.tag_position }}"
-      style="background: {{ block_settings.tag_color.hex }}; color: {{ block_settings.tag_text_color.hex }}"
-    >
-      {{ block_settings.tag_text }}
-    </div>
-  {% endif %}
   <div class='product-thumbnail'>
     {% if item.thumbnail %}
       <img
@@ -25,6 +16,14 @@
         loading='lazy'
         src='{{ 'default_product.jpeg' | asset_url }}'
       >
+    {% endif %}
+    {% if block_settings.tag_text %}
+      <div
+       class="tag {{ block_settings.tag_position }}"
+       style="background: {{ block_settings.tag_color.hex }}; color: {{ block_settings.tag_text_color.hex }}"
+      >
+        {{ block_settings.tag_text }}
+      </div>
     {% endif %}
   </div>
   <div class='product-details'>


### PR DESCRIPTION
## JIRA Ticket

[YSHOP2-316](https://youcanshop.atlassian.net/browse/YSHOP2-316)

## QA Steps

- [ ] `pnpm i`
- [ ] `pnpm dev`
- [ ] In your theme editor, go to `home page` > `Featured products` > `Product`
- [ ] Set `Banner position` to `Bottom right`
- [ ] The banner should be displayed in the bottom right of the image preview instead of the product card

## Note

<img width="307" alt="image" src="https://user-images.githubusercontent.com/85164582/230404318-80c953c9-10e5-4596-8d4a-f7f070f70d61.png">


[YSHOP2-316]: https://youcanshop.atlassian.net/browse/YSHOP2-316?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ