### PR TITLE
YSHOP2-291: The background color should extend full width in mobile

### DIFF
--- a/sections/featured-product-slider.liquid
+++ b/sections/featured-product-slider.liquid
@@ -9,6 +9,7 @@
   .section-featured-products-{{id}} {
     margin-top: {{ section.settings.margin_top }}px;
     margin-bottom: {{ section.settings.margin_bottom }}px;
+    padding: 0;
   }
 
   @media screen and (min-width: 768px) {


### PR DESCRIPTION
## JIRA Ticket

[YSHOP2-291](https://youcanshop.atlassian.net/browse/YSHOP2-291)

## QA Steps

- [ ] `pnpm i`
- [ ] `pnpm dev`
- [ ] In your theme editor, go to `home page` > `Products slider`
- [ ] Change the `background color` setting, make sure it has a visible color
- [ ] Switch to mobile preview, the slider should take space from left to right.
- [ ] Going back to desktop, it should still have the side spacing


[YSHOP2-291]: https://youcanshop.atlassian.net/browse/YSHOP2-291?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ