### PR TITLE
YSHOP2-313: Products Slider > Only one product is displayed when the transition type is Fade

### DIFF
--- a/sections/featured-product-slider.liquid
+++ b/sections/featured-product-slider.liquid
@@ -249,10 +249,6 @@
           "label": "Slide"
         },
         {
-          "value": "fade",
-          "label": "Fade"
-        },
-        {
           "value": "loop",
           "label": "Loop"
         }
@@ -315,10 +311,6 @@
         {
           "value": "slide",
           "label": "Slide"
-        },
-        {
-          "value": "fade",
-          "label": "Fade"
         },
         {
           "value": "loop",


### PR DESCRIPTION
## JIRA Ticket

[YSHOP2-313](https://youcanshop.atlassian.net/browse/YSHOP2-313)

## QA Steps

- [ ] `pnpm i`
- [ ] `pnpm dev`

## Note

Remove fade transition settings, since it's not support perPage option
<img width="862" alt="Screen Shot 2023-04-12 at 13 20 28" src="https://user-images.githubusercontent.com/108662497/231471039-734673e1-8986-4184-ae3d-87f241bcd228.png">

[YSHOP2-313]: https://youcanshop.atlassian.net/browse/YSHOP2-313?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ