### PR TITLE
YSHOP2-404: Stock, description, countdown to be limited to 1

### DIFF
--- a/sections/product.liquid
+++ b/sections/product.liquid
@@ -59,11 +59,13 @@
     },
     {
       "label": "Description",
+      "limit": 1,
       "type": "product_description"
     },
     {
       "label": "Stock",
       "type": "stock",
+      "limit": 1,
       "settings": [
         {
           "label": "Title",
@@ -87,6 +89,7 @@
     {
       "label": "Countdown Timer",
       "type": "countdown_timer",
+      "limit": 1,
       "settings": [
         {
           "label": "Message",


### PR DESCRIPTION
## JIRA Ticket

[YSHOP2-404](https://youcanshop.atlassian.net/browse/YSHOP2-404)

## QA Steps

- [ ] In your home page template go to `Single product` section
- [ ] You shouldn't be able to add more than 1 block of (Description, Countdown and Stock)

## Note

Leave empty when you have nothing to say


[YSHOP2-404]: https://youcanshop.atlassian.net/browse/YSHOP2-404?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ