### PR TITLE
DARK : fix related product slider issue 

### DIFF
--- a/assets/express-checkout.css
+++ b/assets/express-checkout.css
@@ -1,6 +1,7 @@
 @media (min-width: 768px) {
   #express-checkout-form {
-    border: 2px solid #F33520;
+    border-width: 2px;
+    border-style: solid;
     background: #F8F8F8;
     box-shadow: 1px -1px 23px rgba(0, 0, 0, 0.04);
     border-radius: 4px;
@@ -10,7 +11,8 @@
 }
 
 .express-checkout-fields {
-  border: 2px solid #F33520;
+  border-width: 2px;
+  border-style: solid;
   background: #F8F8F8;
   box-shadow: 1px -1px 23px rgba(0, 0, 0, 0.04);
   border-radius: 4px;

--- a/sections/related-products.liquid
+++ b/sections/related-products.liquid
@@ -192,7 +192,7 @@
           "label": "Loop"
         }
       ],
-      "default": "slide"
+      "default": "loop"
     },
     {
       "type": "checkbox",

--- a/snippets/express-checkout.liquid
+++ b/snippets/express-checkout.liquid
@@ -14,9 +14,13 @@
 
   {% endif %}
 
+  .custom-checkout-{{ checkout_id }},
+  .express-checkout-fields {
+    border-color: {{ settings.form_border_colour.hex }};
+  }
+
   .custom-checkout-{{ checkout_id }} .express-checkout-fields  {
     grid-gap: {{ settings.inputs_gap }}px;
-    border-color: {{ settings.form_border_colour.hex }}
   }
 
   .custom-checkout-{{ checkout_id }} input {

--- a/snippets/related-products-slider.liquid
+++ b/snippets/related-products-slider.liquid
@@ -33,7 +33,7 @@
     width: 54px;
     height: 54px;
     margin: 0 148px;
-    z-index: 999;
+    z-index: 90;
     border: 1px solid #EDEDED;
     box-shadow: 4px 10px 76px rgba(0, 0, 0, 0.14);
     border-radius: 0px 8px 8px 0px;

--- a/snippets/related-products-slider.liquid
+++ b/snippets/related-products-slider.liquid
@@ -1,18 +1,32 @@
 {{ 'product-slider.css' | asset_url | stylesheet_tag }}
 
 {% style %}
+  {%- if product.related_products.size >= 3 %}
+    @media (max-width: 768px) {
+      .section-related-products #yc_slider_{{ id }} .splide__slide {
+        width: calc( ((100% + 12px) / 2) - 16px) !important;
+      }
+    }
+  {%- endif %}
 
-{%- if product.related_products.size < 3 %}
-  .section-related-products #yc_slider_{{ id }} .splide__list {
-    transform: unset !important;
-    margin: 0 auto !important;
-    justify-content: center;
-  }
+  {%- if product.related_products.size < 3 %}
+    .section-related-products #yc_slider_{{ id }} .splide__list {
+      transform: unset !important;
+      margin: 0 !important;
+      gap: 10px;
+    }
 
-  .section-related-products #yc_slider_{{ id }} .splide__track {
-    overflow: unset !important;
-  }
-{%- endif %}
+    @media (min-width: 768px) {
+      .section-related-products #yc_slider_{{ id }} .splide__list {
+        justify-content: center;
+        gap: 20px;
+      }
+    }
+
+    .section-related-products #yc_slider_{{ id }} .splide__slide {
+      margin: 0 !important;
+    }
+  {%- endif %}
 
   .section-related-products #yc_slider_{{ id }} .splide__arrow {
     background: white !important;

--- a/styles/express-checkout.scss
+++ b/styles/express-checkout.scss
@@ -4,7 +4,8 @@ $sticky-checkout-padding: 20px;
 
 #express-checkout-form {
   @include breakpoint('md') {
-    border: 2px solid #F33520;
+    border-width: 2px;
+    border-style: solid;
     background: #F8F8F8;
     box-shadow: 1px -1px 23px rgba(0, 0, 0, 0.04);
     border-radius: 4px;
@@ -14,7 +15,8 @@ $sticky-checkout-padding: 20px;
 }
 
 .express-checkout-fields {
-  border: 2px solid #F33520;
+  border-width: 2px;
+  border-style: solid;
   background: #F8F8F8;
   box-shadow: 1px -1px 23px rgba(0, 0, 0, 0.04);
   border-radius: 4px;

--- a/templates/product.json
+++ b/templates/product.json
@@ -147,7 +147,7 @@
               "tag_background_color": "#F4351FFF",
               "tag_position": "top_right",
               "duration_between_each_slide": 5,
-              "slider_transition_type": "slide",
+              "slider_transition_type": "loop",
               "slider_autoplay": true,
               "slider_pause_on_hover": true,
               "slider_pause_on_focus": true,


### PR DESCRIPTION
## Issue 
In the mobile version if you try to slide products from the left side you will see that the container of the related products is bigger than the mobile screen so it will show a big empty white space
## QA Steps

- [ ] `pnpm i`
- [ ] `pnpm dev`

## Note

I have also fix the setting for changing the border color of the express checkout form