### PR TITLE
YSHOP2-983: fix spinner not showing on product page with variants

### DIFF
--- a/assets/add-to-cart.js
+++ b/assets/add-to-cart.js
@@ -18,7 +18,9 @@ async function addToCart(snippetId) {
   }
 
   try {
-    load('#loading__cart');
+    requestAnimationFrame(() => {
+      load('#loading__cart');
+    })
 
     const response = await youcanjs.cart.addItem({
       productVariantId: variantId,


### PR DESCRIPTION
## JIRA Ticket

[YSHOP2-983](https://youcanshop.atlassian.net/browse/YSHOP2-983)

## QA Steps

- [ ] Go to a product page that has variants in it
- [ ] Click on the "add to cart" button
- [ ] The "Add to cart" text should be replaced by a spinner



[YSHOP2-983]: https://youcanshop.atlassian.net/browse/YSHOP2-983?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ